### PR TITLE
Write manifests on disk by dumping yamls instead of writing text files

### DIFF
--- a/make_argocd_fly/application.py
+++ b/make_argocd_fly/application.py
@@ -6,7 +6,7 @@ import textwrap
 
 from make_argocd_fly.resource import ResourceViewer, ResourceWriter
 from make_argocd_fly.renderer import JinjaRenderer
-from make_argocd_fly.utils import multi_resource_parser, merge_dicts
+from make_argocd_fly.utils import multi_resource_parser, merge_dicts, generate_filename
 from make_argocd_fly.config import get_config
 
 log = logging.getLogger(__name__)
@@ -159,10 +159,8 @@ class KustomizeApplication(AbstractApplication):
         content = renderer.render(content, template_vars, yml_child.element_rel_path)
 
       for resource_kind, resource_name, resource_yml in multi_resource_parser(content):
-        tmp_resource_writer.store_resource(
-          self.env_name,
-          os.path.join(self.env_name, os.path.dirname(yml_child.element_rel_path)),
-          resource_kind, resource_name, resource_yml)
+        file_path = os.path.join(self.env_name, os.path.dirname(yml_child.element_rel_path), generate_filename(resource_kind, resource_name))
+        tmp_resource_writer.store_resource(file_path, resource_yml)
 
     await tmp_resource_writer.write_resources()
 

--- a/make_argocd_fly/main.py
+++ b/make_argocd_fly/main.py
@@ -9,7 +9,7 @@ import yaml
 import yamllint
 
 from make_argocd_fly.config import read_config, get_config
-from make_argocd_fly.utils import multi_resource_parser
+from make_argocd_fly.utils import multi_resource_parser, generate_filename
 from make_argocd_fly.resource import ResourceViewer, ResourceWriter
 from make_argocd_fly.application import application_factory
 
@@ -62,7 +62,8 @@ async def generate(render_envs, render_apps) -> None:
 
   for app in apps:
     for resource_kind, resource_name, resource_yml in multi_resource_parser(app.resources):
-      output_writer.store_resource(app.env_name, app.get_app_rel_path(), resource_kind, resource_name, resource_yml)
+      file_path = os.path.join(app.get_app_rel_path(), generate_filename(resource_kind, resource_name))
+      output_writer.store_resource(file_path, resource_yml)
 
   log.debug('Writing resources files')
   if os.path.exists(config.get_output_dir()):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 PyYAML==6.0.1
 Jinja2==3.1.3
 jinja2-ansible-filters==1.3.2
-yamlfix==1.16.0
 yamllint==1.35.1

--- a/tests/manual/output/external_1/app_1/Deployment_grafana.yml
+++ b/tests/manual/output/external_1/app_1/Deployment_grafana.yml
@@ -4,5 +4,6 @@ kind: Deployment
 metadata:
   labels:
     app: grafana_veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long_label
+    lbl: 11.11
   name: grafana
   namespace: monitoring

--- a/tests/manual/output/management/app_1/Deployment_grafana.yml
+++ b/tests/manual/output/management/app_1/Deployment_grafana.yml
@@ -4,5 +4,6 @@ kind: Deployment
 metadata:
   labels:
     app: grafana_veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long_label
+    lbl: 11.11
   name: grafana
   namespace: monitoring

--- a/tests/manual/source/app_1/deployment.yml
+++ b/tests/manual/source/app_1/deployment.yml
@@ -6,3 +6,5 @@ metadata:
   namespace: monitoring
   labels:
     app: grafana_veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long_label
+    # this is a comment and it is going to be discarded
+    lbl: 11.11

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -212,23 +212,17 @@ def test_ResourceWriter_store_resource_multiple(tmp_path):
   resource_writer = ResourceWriter(str(dir_output))
   env_name = 'env'
 
-  resource_writer.store_resource(env_name, 'key_1', 'key_2', 'key_3', 'resource body 1')
-  resource_writer.store_resource(env_name, 'key_1', 'key_2', 'key_4', 'resource body 2')
-  resource_writer.store_resource(env_name, 'key_1', 'key_5', 'key_3', 'resource body 3')
-  resource_writer.store_resource(env_name, 'key_6', 'key_2', 'key_3', 'resource body 4')
-  resource_writer.store_resource(env_name, 'key_7', 'key_8', 'key_9', 'resource body 5')
+  resource_writer.store_resource('/a/b/c', 'resource body 1')
+  resource_writer.store_resource('/a/b/d', 'resource body 2')
+  resource_writer.store_resource('/a/b/e', 'resource body 3')
 
-  assert len(resource_writer.resources) == 5
-  assert (env_name, 'key_1', 'key_2', 'key_3') in resource_writer.resources
-  assert resource_writer.resources[(env_name, 'key_1', 'key_2', 'key_3')] == 'resource body 1'
-  assert (env_name, 'key_1', 'key_2', 'key_4') in resource_writer.resources
-  assert resource_writer.resources[(env_name, 'key_1', 'key_2', 'key_4')] == 'resource body 2'
-  assert (env_name, 'key_1', 'key_5', 'key_3') in resource_writer.resources
-  assert resource_writer.resources[(env_name, 'key_1', 'key_5', 'key_3')] == 'resource body 3'
-  assert (env_name, 'key_6', 'key_2', 'key_3') in resource_writer.resources
-  assert resource_writer.resources[(env_name, 'key_6', 'key_2', 'key_3')] == 'resource body 4'
-  assert (env_name, 'key_7', 'key_8', 'key_9') in resource_writer.resources
-  assert resource_writer.resources[(env_name, 'key_7', 'key_8', 'key_9')] == 'resource body 5'
+  assert len(resource_writer.resources) == 3
+  assert '/a/b/c' in resource_writer.resources
+  assert resource_writer.resources['/a/b/c'] == 'resource body 1'
+  assert '/a/b/d' in resource_writer.resources
+  assert resource_writer.resources['/a/b/d'] == 'resource body 2'
+  assert '/a/b/e' in resource_writer.resources
+  assert resource_writer.resources['/a/b/e'] == 'resource body 3'
 
 def test_ResourceWriter_store_resource_duplicate(tmp_path, caplog):
   dir_output = tmp_path / 'dir_output'
@@ -236,10 +230,10 @@ def test_ResourceWriter_store_resource_duplicate(tmp_path, caplog):
   resource_writer = ResourceWriter(str(dir_output))
   env_name = 'env'
 
-  resource_writer.store_resource(env_name, 'key_1', 'key_2', 'key_3', 'resource body 1')
+  resource_writer.store_resource('/a/b/c', 'resource body 1')
   with pytest.raises(Exception):
-      resource_writer.store_resource(env_name, 'key_1', 'key_2', 'key_3', 'resource body 1')
-  assert 'Resource (env, key_1, key_2, key_3) already exists' in caplog.text
+      resource_writer.store_resource('/a/b/c', 'resource body 1')
+  assert 'Resource (/a/b/c) already exists' in caplog.text
 
 def test_ResourceWriter_store_resource_undefined_dir_rel_path(tmp_path, caplog):
   dir_output = tmp_path / 'dir_output'
@@ -248,39 +242,9 @@ def test_ResourceWriter_store_resource_undefined_dir_rel_path(tmp_path, caplog):
   env_name = 'env'
 
   with pytest.raises(Exception):
-    resource_writer.store_resource(env_name, None, 'key_2', 'key_3', 'resource body 1')
-  assert 'Parameter `dir_rel_path` is undefined' in caplog.text
+    resource_writer.store_resource(None, 'resource body 1')
+  assert 'Parameter `file_path` is undefined' in caplog.text
 
   with pytest.raises(Exception):
-    resource_writer.store_resource(env_name, '', 'key_2', 'key_3', 'resource body 1')
-  assert 'Parameter `dir_rel_path` is undefined' in caplog.text
-
-def test_ResourceWriter_store_resource_undefined_resource_kind(tmp_path, caplog):
-  dir_output = tmp_path / 'dir_output'
-  dir_output.mkdir()
-  resource_writer = ResourceWriter(str(dir_output))
-  env_name = 'env'
-
-  with pytest.raises(Exception):
-    resource_writer.store_resource(env_name, 'key_1', None, 'key_3', 'resource body 1')
-  assert 'Parameter `resource_kind` is undefined' in caplog.text
-
-  with pytest.raises(Exception):
-    resource_writer.store_resource(env_name, 'key_1', '', 'key_3', 'resource body 1')
-  assert 'Parameter `resource_kind` is undefined' in caplog.text
-
-def test_ResourceWriter_assemble_filename(tmp_path):
-  dir_output = tmp_path / 'dir_output'
-  dir_output.mkdir()
-  resource_writer = ResourceWriter(str(dir_output))
-
-  assert resource_writer._assemble_filename('key_1', 'key_2') == 'key_1_key_2.yml'
-  assert resource_writer._assemble_filename('Key_1', 'Key_2') == 'Key_1_Key_2.yml'
-
-def test_ResourceWriter_assemble_filename_undefined_resource_name(tmp_path):
-  dir_output = tmp_path / 'dir_output'
-  dir_output.mkdir()
-  resource_writer = ResourceWriter(str(dir_output))
-
-  assert resource_writer._assemble_filename('key_1', None) == 'key_1.yml'
-  assert resource_writer._assemble_filename('Key_1', None) == 'key_1.yml'
+    resource_writer.store_resource('', 'resource body 1')
+  assert 'Parameter `file_path` is undefined' in caplog.text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 import textwrap
 
-from make_argocd_fly.utils import resource_parser, multi_resource_parser, merge_dicts
+from make_argocd_fly.utils import resource_parser, multi_resource_parser, generate_filename, merge_dicts
 
 ###################
 ### resource_parser
@@ -202,8 +202,8 @@ def test_multi_resource_parser_with_valid_yaml():
 
   result = list(multi_resource_parser(textwrap.dedent(multi_resource_yml)))
   expected = [
-      ('Deployment', 'grafana', '---\nkind: Deployment\nmetadata:\n  name: grafana\n'),
-      ('DaemonSet', 'prometheus', '---\nkind: DaemonSet\nmetadata:\n  name: prometheus\n')
+      ('Deployment', 'grafana', 'kind: Deployment\nmetadata:\n  name: grafana\n'),
+      ('DaemonSet', 'prometheus', 'kind: DaemonSet\nmetadata:\n  name: prometheus\n')
   ]
 
   assert result == expected
@@ -223,8 +223,8 @@ def test_multi_resource_parser_with_valid_yaml_extra_separator_at_the_top():
 
   result = list(multi_resource_parser(textwrap.dedent(multi_resource_yml)))
   expected = [
-      ('Deployment', 'grafana', '---\nkind: Deployment\nmetadata:\n  name: grafana\n'),
-      ('DaemonSet', 'prometheus', '---\nkind: DaemonSet\nmetadata:\n  name: prometheus\n')
+      ('Deployment', 'grafana', 'kind: Deployment\nmetadata:\n  name: grafana\n'),
+      ('DaemonSet', 'prometheus', 'kind: DaemonSet\nmetadata:\n  name: prometheus\n')
   ]
 
   assert result == expected
@@ -244,8 +244,8 @@ def test_multi_resource_parser_with_valid_yaml_extra_separator_at_the_bottom():
 
   result = list(multi_resource_parser(textwrap.dedent(multi_resource_yml)))
   expected = [
-      ('Deployment', 'grafana', '---\nkind: Deployment\nmetadata:\n  name: grafana\n'),
-      ('DaemonSet', 'prometheus', '---\nkind: DaemonSet\nmetadata:\n  name: prometheus\n')
+      ('Deployment', 'grafana', 'kind: Deployment\nmetadata:\n  name: grafana\n'),
+      ('DaemonSet', 'prometheus', 'kind: DaemonSet\nmetadata:\n  name: prometheus\n')
   ]
 
   assert result == expected
@@ -265,11 +265,30 @@ def test_multi_resource_parser_with_valid_yaml_not_an_extra_separator():
 
   result = list(multi_resource_parser(textwrap.dedent(multi_resource_yml)))
   expected = [
-      ('Deployment', 'grafana', '---\nkind: Deployment\nmetadata:\n  name: grafana\n  comment: \'--- This is not an extra separator\'\n'),
-      ('DaemonSet', 'prometheus', '---\nkind: DaemonSet\nmetadata:\n  name: prometheus\n')
+      ('Deployment', 'grafana', 'kind: Deployment\nmetadata:\n  name: grafana\n  comment: "--- This is not an extra separator"\n'),
+      ('DaemonSet', 'prometheus', 'kind: DaemonSet\nmetadata:\n  name: prometheus\n')
   ]
 
   assert result == expected
+
+#####################
+### generate_filename
+#####################
+
+def test_generate_filename_undefined_resource_kind(tmp_path, caplog):
+  with pytest.raises(Exception):
+    generate_filename(None, 'key_1')
+  assert 'Parameter `resource_kind` is undefined' in caplog.text
+
+  with pytest.raises(Exception):
+    generate_filename('', 'key_1')
+  assert 'Parameter `resource_kind` is undefined' in caplog.text
+
+def test_generate_filename(tmp_path):
+  assert generate_filename('key_1', 'key_2') == 'key_1_key_2.yml'
+
+def test_generate_filename_undefined_resource_name(tmp_path):
+  assert generate_filename('key_1', None) == 'key_1.yml'
 
 ###############
 ### merge_dicts


### PR DESCRIPTION
feat: use pyyaml to generate and dump yamls
misc: simplify ResourceWriter by using file_path as resource key
misc: drop yamlfix dependency as output resources are actual yamls now
docs: update general information